### PR TITLE
Fix for prisoners not receiving night owl schedule

### DIFF
--- a/Source/TinyTweaks/HarmonyPatches/NightOwl_Patches.cs
+++ b/Source/TinyTweaks/HarmonyPatches/NightOwl_Patches.cs
@@ -63,7 +63,8 @@ namespace TinyTweaks
             }
         }
 
-        [HarmonyPatch(typeof(InteractionWorker_RecruitAttempt), "DoRecruit", typeof(Pawn), typeof(Pawn), typeof(bool))]
+        [HarmonyPatch(typeof(InteractionWorker_RecruitAttempt), "DoRecruit", new System.Type[] { typeof(Pawn), typeof(Pawn), typeof(string), typeof(string), typeof(bool), typeof(bool) },
+                                                                             new ArgumentType[] { ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Out, ArgumentType.Out, ArgumentType.Normal, ArgumentType.Normal })]
         public static class InteractionWorker_RecruitAttempt_DoRecruit
         {
             public static void Postfix(Pawn recruitee)


### PR DESCRIPTION
When a prisoner is recruited, their timetable is not set to night owl one.

I don't know if it changed in 1.3 but the DoRecruit method has now two versions:

```
public static void DoRecruit(Pawn recruiter, Pawn recruitee, bool useAudiovisualEffects = true)
{
	DoRecruit(recruiter, recruitee, out var _, out var _, useAudiovisualEffects);
}
```
and
```
public static void DoRecruit(Pawn recruiter, Pawn recruitee, out string letterLabel, out string letter, bool useAudiovisualEffects = true, bool sendLetter = true)
{
    ...
}
```

Sometimes (example: the debug function "recruit") the 3 arguments one is called, sometimes the 6 arguments one; patching the latest solves the issue